### PR TITLE
Dependencies update. Switch to prop-types.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+*.gitignore
+Demo/

--- a/Demo/package.json
+++ b/Demo/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react": "15.2.1",
     "react-native": "^0.29.2",
-    "react-native-transformable-image": "0.0.18"
+    "react-native-transformable-image": "shoutem/react-native-transformable-image",
+    "prop-types": "^15.5.10"
   }
 }

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A pure JavaScript written transformable image component, like PhotoView or Image
 
 
 
-Written in pure JS, this component should be one of the most easy to use component among all the zoomable, scrollable PhotoView alike views on react-native. 
+Written in pure JS, this component should be one of the most easy to use component among all the zoomable, scrollable PhotoView alike views on react-native.
 
 ## Install
 
- `npm install --save react-native-transformable-image@latest`
+ `npm install --save shoutem/react-native-transformable-image`
 
 
 
@@ -38,14 +38,14 @@ You can provide `enableTransform`, `enableScale` and `enableTranslate`  props to
 
 #### Other props
 
-* `onTransformGestureReleased` and `onViewTransformed`: 
+* `onTransformGestureReleased` and `onViewTransformed`:
 
-​	inherited from [react-native-view-transformer](https://github.com/ldn0x7dc/react-native-view-transformer)
+​	inherited from [react-native-view-transformer](https://github.com/shoutem/react-native-view-transformer)
 
 ### Attention
 
-* If you are using  react-native v0.27 and below, or if the image source is local (`source={require('...')}`), you should provide the **pixels** prop, like `pixels={{width: 3607, height: 2400}}` (ask your API server to provide the pixels info for remote images). This prop is used to align the edge of the image content with the view's boundry and to determine the max scale.
-* By default, the offical iOS Image component will downsample if the image is larger than the view size. `react-native-transformable-image` disables downsampling to keep more image details when zoomed in. This could cause memory issues if your image is too large.
+* If you are using  react-native v0.27 and below, or if the image source is local (`source={require('...')}`), you should provide the **pixels** prop, like `pixels={{width: 3607, height: 2400}}` (ask your API server to provide the pixels info for remote images). This prop is used to align the edge of the image content with the view's boundary and to determine the max scale.
+* By default, the official iOS Image component will downsample if the image is larger than the view size. `react-native-transformable-image` disables downsampling to keep more image details when zoomed in. This could cause memory issues if your image is too large.
 
 
 

--- a/library/TransformableImage.js
+++ b/library/TransformableImage.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { Image } from 'react-native';
+import PropTypes from 'prop-types';
 
 import ViewTransformer from 'react-native-view-transformer';
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
-    "react-native-view-transformer": "ldn0x7dc/react-native-view-transformer#f7e028b6566022deac4e523052e74c2c63a4af7e"
+    "react-native-view-transformer": "shoutem/react-native-view-transformer#master",
+    "prop-types": "=>15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/ldn0x7dc/react-native-transformable-image#readme",
   "dependencies": {
     "react-native-view-transformer": "shoutem/react-native-view-transformer#master",
-    "prop-types": "=>15.5.10"
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Switched from `React.PropTypes` to `prop-types` package.

Updated dependencies and made it depend on Shoutem's fork of the `react-native-view-transformer`.

Added `.npmignore` file to remove `Demo` folder from `node_modules`.